### PR TITLE
将 Xposed 模块链接改为最新 release 链接

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,7 +60,7 @@
 
     <string name="wizard_title_fake_build">修改 Build.prop 深度伪装MIUI</string>
     <string name="wizard_descr_fake_build"><![CDATA[某些应用（如京东、摩拜单车等）会使用自己的逻辑判断是否是 MIUI，如果是才启用小米推送，否则仍会使用其他推送方式驻留后台。这种判断逻辑通常是解析 build.prop。我们尝试通过向 build.prop 插入一些代表 MIUI 的键值对进行伪装，让这些应用使用小米推送。
-    <br /><br />如果您需要伪装，请先 <a href="http://forum.xda-developers.com/apps/magisk/official-magisk-v7-universal-systemless-t3473445">下载安装 Magisk，点这儿前往XDA</a>。安装完成后，打开 <b>Magisk Manager</b>，下载 <b><a href="https://github.com/cubesky/MiPushFake">MiPushFake</a></b> 模块并激活重启，随后即可完成伪装。]]></string>
+    <br /><br />如果您需要伪装，请先 <a href="http://forum.xda-developers.com/apps/magisk/official-magisk-v7-universal-systemless-t3473445">下载安装 Magisk，点这儿前往XDA</a>。安装完成后，打开 <b>Magisk Manager</b>，下载 <b><a href="https://github.com/cubesky/MiPushFake/releases/latest">MiPushFake</a></b> 模块并激活重启，随后即可完成伪装。]]></string>
     <string name="toast_fake_build_already_enable">您已开启该项设置，如需取消，请前往 Magisk Manager 并卸载或取消激活 MiPushFake 模块。</string>
 
     <string name="wizard_descr_finish">大功告成！您可以开始使用了</string>


### PR DESCRIPTION
手机版 GitHub 上 release 页面不是很好找到，该项目的 README 也没有直接给出下载链接