### PR TITLE
AuthActivity: Exclude from Recents List

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -100,6 +100,7 @@
 
         <activity android:name="top.trumeet.mipushframework.auth.AuthActivity"
             android:theme="@style/Theme.Transparent"
+            android:excludeFromRecents="true"
             android:configChanges="screenLayout|screenSize|orientation"/>
 
         <provider


### PR DESCRIPTION
It's unnecessary to keep AuthActivity in Recents List.