### PR TITLE
feat(app/common/push): add 'en' locale, I18n fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        resConfigs "zh"
+        resConfigs "zh", "en"
         ndk {
             abiFilters 'armeabi', 'armeabi-v7a', 'x86'
         }

--- a/app/src/main/java/top/trumeet/mipushframework/permissions/ManagePermissionsActivity.java
+++ b/app/src/main/java/top/trumeet/mipushframework/permissions/ManagePermissionsActivity.java
@@ -366,7 +366,7 @@ public class ManagePermissionsActivity extends AppCompatActivity {
                     screen);
 
             if (new File(Constants.FAKE_CONFIGURATION_GLOBAL).exists()) {
-                fakeSwtich.setSummary(R.string.fake_enable_globe);
+                fakeSwtich.setSummary(R.string.fake_enable_global);
                 fakeSwtich.setEnabled(false);
                 fakeSwtich.setChecked(true);
             }

--- a/app/src/main/java/top/trumeet/mipushframework/settings/SettingsFragment.java
+++ b/app/src/main/java/top/trumeet/mipushframework/settings/SettingsFragment.java
@@ -84,7 +84,7 @@ public class SettingsFragment extends PreferenceFragment {
                     Log.d(TAG, "Exit: " + ShellUtils.execCmd(commands, true, true).toString());
                     return true;
                 },
-                "全局" + getString(R.string.fake_enable_title),
+                getString(R.string.fake_global_enable_title),
                 getString(R.string.fake_enable_detail),
                 getPreferenceScreen().findPreference("activity_keep_alive").getParent()
         );

--- a/app/src/main/java/top/trumeet/mipushframework/wizard/CheckRunInBackgroundActivity.java
+++ b/app/src/main/java/top/trumeet/mipushframework/wizard/CheckRunInBackgroundActivity.java
@@ -53,7 +53,7 @@ public class CheckRunInBackgroundActivity extends PushControllerWizardActivity i
         if (controller != null && controller.isConnected() && !isConnecting()) {
             mText.setText(Html.fromHtml(getString(R.string.wizard_descr_run_in_background, Build.VERSION.SDK_INT >= 26 ?
                     "" : (Utils.isAppOpsInstalled() ? getString(R.string.run_in_background_rikka_appops) :
-                    getString(R.string.run_in_background_appops_root)))));
+                    getString(R.string.run_in_background_appops_root))))); // TODO: I18n more, no append.
 
             int result = controller.checkOp(AppOpsManagerOverride.OP_RUN_IN_BACKGROUND);
             allow = (result == AppOpsManager.MODE_ALLOWED);

--- a/app/src/main/res/values-en-v26/strings.xml
+++ b/app/src/main/res/values-en-v26/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="settings_manage_app_notifications">Manage notifications</string>
+    <string name="settings_manage_app_notifications_summary">Control the sound, importance level, etc. of the app notifications.</string>
+</resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">MiPush Framework (community edition)</string>
+    <string name="app_name">MiPush Framework</string>
 
     <string name="loading">Please wait…</string>
     <string name="enable">Enable</string>
@@ -91,7 +91,7 @@ Please grant the <b>Run in the background or wake up</b> permissions.
     <string name="permission_allow_register">Register push</string>
     <string name="permission_allow_receive">Receive notification message</string>
     <string name="permission_allow_receive_command">Receive command</string>
-    <string name="permission_allow_receive_register_result">Receive registration result</string>
+    <string name="permission_allow_receive_register_result">Receive registration result (not implemented)</string>
     <string name="permission_notification_on_register">Show notification when registering</string>
 
     <string name="permission_register_type">Register mode</string>
@@ -102,11 +102,6 @@ Please grant the <b>Run in the background or wake up</b> permissions.
         <item>@string/register_type_ask</item>
         <item>@string/register_type_allow</item>
         <item>@string/register_type_deny</item>
-    </string-array>
-    <string-array name="register_entries" translatable="false">
-        <item>0</item>
-        <item>2</item>
-        <item>3</item>
     </string-array>
 
     <!-- Settings -->
@@ -160,12 +155,6 @@ The manager is not compatible with the version of the Push service you are curre
     <string name="connect_fail_text_is_miui"><![CDATA[ Sorry, we do not officially support the MIUI ROMs.     ]]></string>
 
     <!-- Help -->
-    <string-array name="help_articles" translatable="false">
-        <item>help_article_can_not_receive_push|can_not_receive_push</item>
-        <item>help_article_register_error|register_error</item>
-        <item>help_article_no_register|no_register</item>
-    </string-array>
-
     <string name="help_article_can_not_receive_push">Cannot to receive push</string>
     <string name="help_article_register_error">Registration failed</string>
     <string name="help_article_no_register">Registration list is empty</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,0 +1,215 @@
+<resources>
+    <string name="app_name">MiPush Framework (community edition)</string>
+
+    <string name="loading">Please wait…</string>
+    <string name="enable">Enable</string>
+    <string name="success">Success</string>
+    <string name="fail">Fail</string>
+    <string name="apply">Apply</string>
+    <string name="retry">Retry</string>
+    <string name="exit">Exit</string>
+
+    <!-- Preference -->
+    <string name="preference_title">Push Config</string>
+    <string name="main_event">Logs</string>
+    <string name="main_apps">Apps</string>
+    <string name="main_settings">Configs</string>
+
+    <!-- Message when change enable status -->
+    <string name="msg_enable">Enabled, Push service is ready.</string>
+    <string name="msg_disable">Disabled, Apps can\'t receive and register to Push service.</string>
+
+    <!-- About -->
+    <string name="action_about">About</string>
+
+    <!-- Wizard -->
+    <string name="wizard_descr"><![CDATA[This is an open source project that allows other Android devices to enjoy XiaoMi system-level Push. For more details, visit the GitHub project:<a href="https://github.com/Trumeet/MiPushFramework">MiPushFramework</a>]]></string>
+    <string name="wizard_title_check_running">Check the running status.</string>
+    <string name="wizard_descr_check_running">Automatically checking if the push service is working properly, which can take up to about twenty seconds.</string>
+    <string name="wizard_descr_check_running_ok">Success! Push service is running. You should not need to perform any special operations.</string>
+    <string name="wizard_descr_check_running_fail">The check found some issues: Push service was not running. It may be that some of the tools or systems on your device are preventing its startup, and we will try to lift these restrictions next.</string>
+
+    <string name="wizard_title_start_fail">Service start failed</string>
+    <string name="service_not_running_faq">
+        <![CDATA[
+            <b>Please avoid any applications, settings to optimize, prohibit the manager and push service.</b>
+            <br /><br /><b>Still have problems?</b>
+            <br /><a href="https://github.com/Trumeet/MiPushFramework/issues/">Submit an issue</a>.
+        ]]>
+    </string>
+
+    <string name="wizard_connect">Connecting</string>
+
+    <string name="wizard_title_run_in_background">Allow running in background</string>
+    <string name="wizard_descr_run_in_background">You have disabled the Push service to run in the background, it will not be able to push in the background, you %1$s, then tap Next button.</string>
+
+    <string name="run_in_background_appops_root">Need to use Root access to solve. (we will handle it automatically)</string>
+    <string name="run_in_background_rikka_appops"><![CDATA[ need to open <b>App Ops</b> tool, and grant the <b>Run in the background or wake up</b> permissions ]]></string>
+    <string name="rikka_appops_help_toast"><![CDATA[
+Please grant the <b>Run in the background or wake up</b> permissions.
+    ]]></string>
+
+    <string name="wizard_title_stats_permission">Usage stats</string>
+    <string name="wizard_title_stats_permission_text">You need to grant "Usage" permission or you will not be able to receive notifications.</string>
+
+    <string name="wizard_descr_finish">Everything is ready.</string>
+
+    <string name="status_ok">OK</string>
+    <string name="status_deny_disable">Push disabled</string>
+    <string name="status_deny_user">Rejected by you</string>
+
+    <!-- Date parse -->
+    <eat-comment />
+    <!-- Date format -->
+    <!-- Just, < 1 min -->
+    <string name="date_just">Just Now</string>
+    <!-- 1 Minute ago, >= 1 Minute, < 60 Minutes -->
+    <plurals name="date_minutes">
+        <item quantity="one">Minute</item>
+        <item quantity="other">Minutes</item>
+    </plurals>
+    <!-- 1 Hours ago, >= 1 hour, < 24 hours -->
+    <plurals name="date_hours">
+        <item quantity="one">Hour</item>
+        <item quantity="other">Hours</item>
+    </plurals>
+    <!-- 1 Day ago, >= 1 day, < days -->
+    <plurals name="date_days">
+        <item quantity="one">Day</item>
+        <item quantity="other">Days</item>
+    </plurals>
+    <!-- For non-just and non-long format -->
+    <string name="date_format_normal">%1$s %2$s ago</string>
+    <!-- For Just format -->
+    <string name="date_format_just">%1$s</string>
+    <!-- For Long ago format -->
+    <string name="date_format_long">%1$s</string>
+
+    <!-- Permission -->
+    <string name="action_edit_permission">Edit Permissions</string>
+    <string name="permissions">Permissions</string>
+    <string name="permission_allow_register">Register push</string>
+    <string name="permission_allow_receive">Receive notification message</string>
+    <string name="permission_allow_receive_command">Receive command</string>
+    <string name="permission_allow_receive_register_result">Receive registration result</string>
+    <string name="permission_notification_on_register">Show notification when registering</string>
+
+    <string name="permission_register_type">Register mode</string>
+    <string name="register_type_allow">Allow registration, automatic</string>
+    <string name="register_type_deny">Block registration</string>
+    <string name="register_type_ask">Ask me (Default)</string>
+    <string-array name="register_types">
+        <item>@string/register_type_ask</item>
+        <item>@string/register_type_allow</item>
+        <item>@string/register_type_deny</item>
+    </string-array>
+    <string-array name="register_entries" translatable="false">
+        <item>0</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
+
+    <!-- Settings -->
+    <string name="settings_enhance">Enhances</string>
+    <string name="settings_service_setting">Push configs</string>
+    <string name="settings_service_advance_setting">Advanced</string>
+    <string name="settings_summary_service_advance_setting">Advanced configurations interface</string>
+    <string name="settings_fake_build">Fake build.prop</string>
+    <string name="settings_fake_build_summary">Some apps only try to register to Xiaomi Push when they see the system is XiaoMi MIUI. We can add some keys ​​to build.prop to fake as MIUI and make these applications try to register.</string>
+    <string name="settings_check_service">Check the Push service</string>
+    <string name="settings_check_service_summary">Check Push service running</string>
+    <string name="settings_skip_doze">Remove from battery optimization</string>
+    <string name="settings_skip_doze_summary">Battery Optimizer breaks Push service in Android 6.0 or higher.</string>
+
+    <string name="settings_summary_wakeup_target">We will launch the target app when we receive its notification. Disabling this option will prevent some apps from sending notifications again, but some notifications may be missed.</string>
+    <string name="settings_debug_icon">Debug Icon</string>
+
+    <string name="settings_debug">Debug</string>
+    <string name="settings_get_log">Get debugging logs</string>
+    <string name="settings_get_log_summary">Tap to sharing logs file, submit it to your issue if you can.</string>
+
+    <string name="settings_activity_keep_alive">Push KeepAlive</string>
+    <string name="settings_summary_keep_alive">Many ROMs (such as OnePlus) have their own background cleanup, but you can adding whitelist through the Lock button of Recent tasks interface. After tapping, find the interface you just opened in the system\'s Recent Tasks and lock it, let the Push running in the background.</string>
+
+    <!-- Recent Activity -->
+    <string name="recent_activity_view">View recent events</string>
+    <string name="recent_activity_title">Recent events</string>
+
+    <!-- Update -->
+    <string name="action_help">Help</string>
+    <string name="action_update">Check for update</string>
+    <string name="update_toast">You can downloads the latest APKs from the Releases page.</string>
+
+    <!-- Manage applications, individual application info screen title. For example, if they click on "Browser" in "Manage applications", the title of the next screen will be this -->
+    <string name="application_info_label">App info</string>
+
+    <!-- Fail reasons -->
+    <string name="connect_fail_title_unknown">Unable to connect to Push service</string>
+    <string name="connect_fail_title_low_version">Please upgrade Push service</string>
+    <string name="connect_fail_title_not_installed">Require Push service installed</string>
+    <string name="connect_fail_title_rom">Does not support your ROM</string>
+    <string name="connect_fail_doze">Require removed from battery optimization</string>
+
+    <string name="connect_fail_text_unknown"><![CDATA[
+    <b>The Manager cannot connect to Push service.</b> Please try to remove the restrictions (such as adding <b>%1$s</b> to whitelist) and try again.
+    ]]></string>
+    <string name="connect_fail_text_low_version"><![CDATA[
+The manager is not compatible with the version of the Push service you are currently using: %1$s. Please <a href="%2$s">Upgrade</a> and try again.
+    ]]></string>
+    <string name="connect_fail_text_not_installed"><![CDATA[ You also need to install a push.apk, which is a core service running in the background. <a href="%1$s">Install it</a>, then try again.     ]]></string>
+    <string name="connect_fail_text_is_miui"><![CDATA[ Sorry, we do not officially support the MIUI ROMs.     ]]></string>
+
+    <!-- Help -->
+    <string-array name="help_articles" translatable="false">
+        <item>help_article_can_not_receive_push|can_not_receive_push</item>
+        <item>help_article_register_error|register_error</item>
+        <item>help_article_no_register|no_register</item>
+    </string-array>
+
+    <string name="help_article_can_not_receive_push">Cannot to receive push</string>
+    <string name="help_article_register_error">Registration failed</string>
+    <string name="help_article_no_register">Registration list is empty</string>
+
+    <string name="connect_fail_test_se"><![CDATA[
+    <b>Insufficient permissions, probably because of an upgrade, please try to reinstall the Manager app without uninstall or clearing data.
+    <a href="%1$s">Download it</a>.</b>
+    ]]></string>
+
+
+    <string name="settings_group_notification">Enable notifications grouping</string>
+    <string name="settings_summary_group_notification">May consuming battery, turn off if Push service gulp power.</string>
+
+    <string name="about_version">Version %1$s</string>
+    <string name="app_registered">Registered</string>
+    <string name="app_registered_error">Unregistered</string>
+
+    <string name="request_battery_whitelist">Push app needs to be added to the \"Battery Optimization\" whitelist to run properly.</string>
+
+    <string name="status_app_not_registered">Support but not registered</string>
+    <string name="footer_app_ignored_not_registered">%1$s apps without MiPush SDK</string>
+    <string name="status_app_not_registered_detail_without_fake_suggest"><![CDATA[
+Registration is determined and initiated by the application and generally begins automatically when the application is launched. Some apps are only registered when finding a XiaoMi devices. See also: <b><a href="https://github.com/Trumeet/MiPushFramework/wiki/%E5%BA%94%E7%94%A8%E7%A8%8B%E5%BC%8F%E6%B3%A8%E5%86%8C%E9%97%AE%E9%A2%98%E8%A7%A3%E5%86%B3%E6%96%B9%E6%A1%88">应用程式注册问题解决方案</a></b> and <b><a href="https://github.com/Trumeet/MiPushFramework/wiki/%5B%E5%B8%AE%E5%8A%A9%5D-%E5%BA%94%E7%94%A8%E6%B3%A8%E5%86%8C%E9%97%AE%E9%A2%98">[帮助] 应用注册问题</a></b>.
+    ]]></string>
+    <string name="status_app_not_registered_detail_with_fake_suggest"><![CDATA[
+Registration is determined and initiated by the application and generally begins automatically when the application is launched. Some apps are only registered when finding a XiaoMi devices, you can try <b><a href="https://github.com/Magisk-Modules-Repo/MiPushFake">Magisk global-level module</a></b> or <b><a href="https://github.com/TimothyZhang023/Riru-MiPushFake">Magisk apps-level module</a></b> to increase success. See also: <b><a href="https://github.com/Trumeet/MiPushFramework/wiki/%E5%BA%94%E7%94%A8%E7%A8%8B%E5%BC%8F%E6%B3%A8%E5%86%8C%E9%97%AE%E9%A2%98%E8%A7%A3%E5%86%B3%E6%96%B9%E6%A1%88">应用程式注册问题解决方案</a></b> and <b><a href="https://github.com/Trumeet/MiPushFramework/wiki/%5B%E5%B8%AE%E5%8A%A9%5D-%E5%BA%94%E7%94%A8%E6%B3%A8%E5%86%8C%E9%97%AE%E9%A2%98">[帮助] 应用注册问题</a></b>.
+    ]]></string>
+    <string name="status_app_not_registered_title">Unregistered</string>
+
+    <string name="fake_enable_title">Fake as XiaoMi Phone</string>
+    <string name="fake_global_enable_title">Global fake as XiaoMi Phone</string>
+    <string name="fake_enable_detail">Fake the phone to Xiaomi via an Xposed module or Magisk module, enable other applications to registers. (Require Root)</string>
+    <string name="fake_enable_detail_not_suggested">Not recommended for this app, it may not work properly.</string>
+    <string name="fake_enable_global">Global fake ON</string>
+    <string name="helplib_action_about">About</string>
+    <string name="helplib_action_issue">Feedback</string>
+    <string name="helplib_action_telegram_group">Join Telegram group</string>
+    <string name="helplib_title"><![CDATA[Help & Support]]></string>
+    <string name="helplib_title_contact">Contact us</string>
+    <string name="helplib_title_faq">Frequently asked questions</string>
+    <string name="status_app_registered_error_title">Unregistered</string>
+    <string name="status_app_registered_error_desc"><![CDATA[
+This could be the application doing a reverse registration, or the registration mismatch with the Push service. See also <b><a href="https://github.com/Trumeet/MiPushFramework/wiki/%5B%E5%B8%AE%E5%8A%A9%5D-%E6%B3%A8%E5%86%8C%E5%BC%82%E5%B8%B8">[帮助] 注册异常</a></b>.
+    ]]></string>
+
+
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">小米推送服务</string>
 
-    <string name="loading">请稍后</string>
+    <string name="loading">请稍候……</string>
     <string name="enable">启用</string>
     <string name="success">成功了</string>
     <string name="fail">失败</string>
@@ -151,7 +151,7 @@
     <!-- Update -->
     <string name="action_help">帮助</string>
     <string name="action_update">检查更新</string>
-    <string name="update_toast">请从 Release 页面下载最新的版本。（下载并安装 manager.apk 和 push.apk）</string>
+    <string name="update_toast">您可以从 Releases 页面下载最新版本的两份 APK 文件用以安装。</string>
 
     <!-- Manage applications, individual application info screen title. For example, if they click on "Browser" in "Manage applications", the title of the next screen will be this -->
     <string name="application_info_label">应用信息</string>
@@ -217,9 +217,11 @@
     <string name="status_app_registered_error_title">注册异常</string>
 
     <string name="fake_enable_title">伪装为小米设备</string>
+    <string name="fake_global_enable_title">全局伪装为小米设备</string>
     <string name="fake_enable_detail">通过 Xposed 伪装模块或 Magisk 单应用伪装模块，使其他应用误认本机为小米设备，从而增加注册的数量（需要 ROOT 权限）</string>
     <string name="fake_enable_detail_not_suggested">不建议对此应用开启，可能影响正常运行</string>
-    <string name="fake_enable_globe">全局伪装已开启</string>
+    <string name="fake_enable_global">全局伪装已开启</string>
+    <string name="settings_debug">调试</string>
 
 
 </resources>

--- a/common/src/main/res/values-en/strings.xml
+++ b/common/src/main/res/values-en/strings.xml
@@ -1,0 +1,36 @@
+<resources>
+    <string name="push_service_name">Push</string>
+    <string name="enable">Enable</string>
+    <string name="disable">Disable</string>
+
+    <string name="start">Start</string>
+    <string name="end">End</string>
+
+
+    <string name="perm_change_settings">Manage Push service</string>
+    <string name="perm_read_settings">Get Push settings</string>
+
+    <!-- Event -->
+    <string name="event_register">Register push</string>
+    <string name="event_register_result">Receive register result</string>
+
+    <!-- Notification but no title -->
+    <string name="event_push">Receive notification</string>
+
+    <string name="event_command">Receive command</string>
+
+    <!-- Permissions -->
+    <string name="request_permission">We need permissions to work</string>
+
+
+    <string name="error_usage_stats">Getting UsageStatis error. If your system does not support this feature, switch the \"Foreground app detection mode\" to Accessibility mode in the manager\'s settings.</string>
+
+
+
+    <string name="wizard_title_doze_whitelist">Remove battery optimization</string>
+    <string name="wizard_descr_doze_whitelist">The Push service will not keep running if it is \'battery optimized\'. Please click the button below to request adding it to battery-optimized whitelist (some ROMs may not be supported, if you do not respond after clicking, please click \"Next\".)</string>
+    <string name="wizard_button_remove_doze">Remove battery optimization</string>
+    <string name="settings_debug">Debug</string>
+
+
+</resources>

--- a/push/src/main/java/com/xiaomi/xmsf/push/service/XMPushService.java
+++ b/push/src/main/java/com/xiaomi/xmsf/push/service/XMPushService.java
@@ -103,24 +103,23 @@ public class XMPushService extends IntentService {
                 if (application != null && application.isNotificationOnRegister()) {
                     try {
                         CharSequence appName = getPackageManager().getApplicationLabel(getPackageManager().getApplicationInfo(pkg, 0));
-                        CharSequence typeString;
+                        CharSequence usedString;
                         switch (result) {
                             case Event.ResultType.OK:
                             case Event.ResultType.DENY_DISABLED:
-                                typeString = getString(R.string.allow);
+                                usedString = getString(R.string.notification_registerAllowed, appName);
                                 break;
                             case Event.ResultType.DENY_USER:
-                                typeString = getString(R.string.deny);
+                                usedString = getString(R.string.notification_registerRejected, appName);
                                 break;
                             default:
-                                typeString = null;
+                                usedString = null;
                                 break;
                         }
-                        if (typeString != null) {
+                        if (usedString != null) {
                             new Handler(Looper.getMainLooper()).post(() -> {
                                 try {
-                                    Toast.makeText(this, getString(R.string.notification_register,
-                                            appName, typeString),
+                                    Toast.makeText(this, usedString,
                                             Toast.LENGTH_SHORT)
                                             .show();
                                 } catch (Throwable ignored) {

--- a/push/src/main/java/com/xiaomi/xmsf/push/service/XMPushService.java
+++ b/push/src/main/java/com/xiaomi/xmsf/push/service/XMPushService.java
@@ -106,8 +106,10 @@ public class XMPushService extends IntentService {
                         CharSequence usedString;
                         switch (result) {
                             case Event.ResultType.OK:
-                            case Event.ResultType.DENY_DISABLED:
                                 usedString = getString(R.string.notification_registerAllowed, appName);
+                                break;
+                            case Event.ResultType.DENY_DISABLED:
+                                usedString = null; // Should not be notified?
                                 break;
                             case Event.ResultType.DENY_USER:
                                 usedString = getString(R.string.notification_registerRejected, appName);

--- a/push/src/main/res/values-en/strings.xml
+++ b/push/src/main/res/values-en/strings.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="common_err">%1$s</string>
+
+    <!-- Xposed -->
+    <string name="xposed_description">Fake XiaoMi Phone plugin, turn on if you need it.</string>
+
+    <!-- Auth -->
+    <string name="auth_message"><![CDATA[Do you want to allow  <b>%1$s</b> to push messages? If you are unsure, try <b>Allow one time</b>.]]></string>
+    <string name="allow">Allow</string>
+    <string name="deny">Reject</string>
+    <string name="allow_once">Allow one time</string>
+
+    <!-- Log -->
+    <!-- TOOD: See the "wake-up intercep-tion" shown, why?-->
+    <string name="log_push_err">Push service failed. Please try to disable the wake-up interception for the manager application, turn off some optimization feature of ROMs.</string>
+    <string name="log_none">No logs yet.</string>
+    <string name="log_share_error">Cannot to share logs：%1$s</string>
+    <string name="log_clear_done">Logs cleaned.</string>
+
+
+    <!-- Notification -->
+    <string name="notification_group_config">Config</string>
+    <string name="notification_category_alive">Push Status</string>
+    <string name="notification_category_warning">Warning</string>
+    <string name="notification_alive">Mi Push running</string>
+
+    <string name="notification_group_applications">Applications</string>
+
+    <!-- Stats permission guide -->
+    <!-- TOOD: Need a simple explanation to users -->
+    <string name="notification_stats_permission_title">Please grant usage stats permission</string>
+    <string name="notification_stats_permission_text">We need usage rights to process your request, tap to grant permissions.</string>
+    <string name="title_activity_keepalive">Push stay</string>
+
+    <string name="activity_rom_keepalive">If your ROM may intercept the operations of the Push service, please add the Push application to whitelists (such as battery optimization, wake-up interception, etc.) in relevant settings of your ROM. You can also try to open the system\'s \"Recent Tasks\" interface and Lock this interface to keep the Push service running in the background.</string>
+    <string name="see_pass_though_msg">Forwarded message, check it by opening the app.</string>
+
+    <string name="notification_registerAllowed">Allowed "%1$s" register to MiPush</string>
+    <string name="notification_registerRejected">Rejected "%1$s" register to MiPush</string>
+
+    <string name="settings_clear">Clean up</string>
+
+    <string name="title_activity_advance_setting">Advanced</string>
+    <string name="settings_clear_history_summary">Cleanup logs for more than 7 days.</string>
+    <string name="settings_clear_history">Cleanup logs</string>
+
+    <string name="settings_clear_log">Clear logs</string>
+    <string name="settings_clear_log_summary">Delete logs file.</string>
+
+
+
+    <string name="settings_summary_push_icon">Turning on the icon can solve some applications and systems can not find the Push application.</string>
+    <string name="settings_push_icon">Show Push app icon</string>
+
+
+    <string name="settings_auto_register">Automatic registers</string>
+
+
+    <string name="settings_options">Config</string>
+
+
+    <string name="pref_title_access_mode">Foreground app detection mode</string>
+    <string name="pref_summary_access_mode">It will be used when taps on Push notification.</string>
+
+
+    <string-array name="pref_title_access_mode_list_titles">
+        <item>UsageStats API (good performance, recommended)</item>
+        <item>Accessibility mode (more compatibility)</item>
+    </string-array>
+
+    <string-array name="pref_title_access_mode_list_values">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+    <string name="settings_mock_notification">Simulate received a message</string>
+    <string name="settings_mock_notification_summary">Tap to send a simulated test message.</string>
+    <string name="debug_test_title">This is Title</string>
+    <string name="debug_test_content">This is Content</string>
+    <string name="accessibility_desc">Used for the alternate foreground application detection mode, higher compatibility, but poor performance.</string>
+</resources>

--- a/push/src/main/res/values/strings.xml
+++ b/push/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="allow_once">允许一次</string>
 
     <!-- Log -->
-    <string name="log_push_err">PUSH 服务异常, 请尝试取消对管理器应用的唤醒拦截、关闭 ROM 的高级优化功能。</string>
+    <string name="log_push_err">Push 服务异常, 请尝试取消对管理器应用的唤醒拦截、关闭 ROM 的高级优化功能。</string>
     <string name="log_none">尚无日志</string>
     <string name="log_share_error">无法分享日志：%1$s</string>
     <string name="log_clear_done">清空日志成功</string>
@@ -37,7 +37,8 @@
     <string name="activity_rom_keepalive">当您的 ROM 可能拦截推送服务的正常运行时，请在您的 ROM 的有关设置中将 Push 应用加入白名单（如电池优化、唤醒拦截等功能）。\n您也可尝试打开系统的“最近任务”界面，将本界面“锁定”以保持服务的后台运行。</string>
     <string name="see_pass_though_msg">穿透消息，请打开应用查看</string>
 
-    <string name="notification_register">已%2$s %1$s 注册小米推送</string>
+    <string name="notification_registerAllowed">已允许 %1$s 注册小米推送</string>
+    <string name="notification_registerRejected">已拒绝 %1$s 注册小米推送</string>
 
     <string name="settings_clear">清理</string>
 

--- a/push/src/main/res/xml/fragmented_preferences.xml
+++ b/push/src/main/res/xml/fragmented_preferences.xml
@@ -45,6 +45,7 @@
             android:title="@string/settings_auto_register" />
 
 
+        <!-- TODO: entryValues's height is insufficient for 'en' locale. -->
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/pref_title_access_mode_list_titles"


### PR DESCRIPTION
添加英文版界面。用处多大不知道，不过觉得有趣就做了。仔细测试过，基本都没问题。
琐碎的字符串调整和优化。

`Deny`改为`Reject`，Deny好像更接近否认，Reject则是比较正式的拒绝申请。Refuse也考虑过，不过Reject更严肃一些。`Deny`的代码方面没改，因为地方不少，会弄乱diff。
`"app_name">MiPush Framework (community edition)`不知道是否OK。主界面左上`Push Config`没改。
未注册和注册异常的帮助文件引用，保持了中文，因为还只有中文文档。