### PR TITLE
fix(push): skip intent from manager

### DIFF
--- a/push/src/main/java/com/xiaomi/xmsf/push/service/XMPushService.java
+++ b/push/src/main/java/com/xiaomi/xmsf/push/service/XMPushService.java
@@ -43,9 +43,12 @@ public class XMPushService extends IntentService {
                 Log4a.e(TAG, "Package name is NULL!");
                 return;
             }
+            if (pkg.equals("top.trumeet.mipush")) {
+                return; // Skipping strange registrations while manager is started
+            }
             int result;
             boolean register = true;
-            // Check multi request
+            // Check for fast requests via MIN_REQUEST_INTERVAL
             if (!RemoveTremblingUtils.getInstance().onCallRegister(pkg)) {
                 Log4a.d(TAG, "Don't register multi request " + pkg);
                 register = false;


### PR DESCRIPTION
20181027（不含）之后的版本，管理器启动时有两次奇怪的注册（`XMPush sdk will register push twice (sometimes lots of) times when init.`注释有提到，但以前没有副作用）。
调试很久没找到原因。考虑直接过滤掉，避免“注册成功”事件及通知。因为应用列表中看不到注册的管理器，无从修改“注册时显示通知”。
#215