### PR TITLE
feat(app): quickly open app permissions from events

### DIFF
--- a/app/src/main/java/top/trumeet/mipushframework/event/EventFragment.java
+++ b/app/src/main/java/top/trumeet/mipushframework/event/EventFragment.java
@@ -55,8 +55,9 @@ public class EventFragment extends Fragment implements SwipeRefreshLayout.OnRefr
         super.onCreate(savedInstanceState);
         mTargetPackage = getArguments() == null ? null :
                 getArguments().getString(EXTRA_TARGET_PACKAGE);
+        boolean isSpecificApp = (mTargetPackage != null); // from "Recent Activity"
         mAdapter = new MultiTypeAdapter();
-        mAdapter.register(Event.class, new EventItemBinder(mTargetPackage != null));
+        mAdapter.register(Event.class, new EventItemBinder(isSpecificApp));
     }
 
     SwipeRefreshLayout swipeRefreshLayout;

--- a/app/src/main/java/top/trumeet/mipushframework/event/EventItemBinder.java
+++ b/app/src/main/java/top/trumeet/mipushframework/event/EventItemBinder.java
@@ -30,10 +30,10 @@ import top.trumeet.mipushframework.utils.ParseUtils;
 
 public class EventItemBinder extends BaseAppsBinder<Event> {
 
-    private boolean clickEnabled = true;
-    EventItemBinder(boolean clickEnabled) {
+    private boolean isSpecificApp = true;
+    EventItemBinder(boolean isSpecificApp) {
         super();
-        this.clickEnabled = clickEnabled;
+        this.isSpecificApp = isSpecificApp;
     }
 
     @Override
@@ -66,19 +66,18 @@ public class EventItemBinder extends BaseAppsBinder<Event> {
                         Utils.getUTC(), holder.itemView.getContext()));
         holder.status.setText(status);
 
-        if (clickEnabled) {
-            holder.itemView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    Dialog dialog = createInfoDialog(type,
-                            holder.itemView.getContext());
-                    if (dialog == null)
-                        startManagePermissions(type, holder.itemView.getContext());
-                    else
-                        dialog.show();
+        holder.itemView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Dialog dialog = createInfoDialog(type,
+                        holder.itemView.getContext()); // "Developer info" dialog for event messages
+                if (dialog != null && isSpecificApp) {
+                    dialog.show();
+                } else {
+                    startManagePermissions(type, holder.itemView.getContext());
                 }
-            });
-        }
+            }
+        });
     }
 
     @Nullable
@@ -106,6 +105,7 @@ public class EventItemBinder extends BaseAppsBinder<Event> {
     }
 
     private static void startManagePermissions (EventType type, Context context) {
+        // Issue: This currently allows overlapping opens.
         context.startActivity(new Intent(context,
                 ManagePermissionsActivity.class)
                 .putExtra(ManagePermissionsActivity.EXTRA_PACKAGE_NAME,


### PR DESCRIPTION
1. 点“记录”中的条目，打开应用的修改权限面板。原为无反应。
2. 点“查看近期活动”中的项目，“注册推送”等继续打开修改权限，其他消息继续打开开发者信息对话框。同以前。